### PR TITLE
Ubuntu/nodejs compatibility fix

### DIFF
--- a/slave/Dockerfile
+++ b/slave/Dockerfile
@@ -5,7 +5,7 @@ FROM ubuntu:latest
 RUN apt-get update
 
 # Install Java, Git, Maven, NPM
-RUN apt-get install -y --no-install-recommends openjdk-7-jdk git maven nodejs npm
+RUN apt-get install -y --no-install-recommends openjdk-7-jdk git maven nodejs nodejs-legacy npm 
 RUN apt-get clean
 
 # Install an SSH server for jenkins slave


### PR DESCRIPTION
Fix some Ubuntu behavior that seems to have changed recently.

Due to the existence of another package called 'node', installing npm+node on Ubuntu is a little twitchy.  As the code currently exists, the image being built has only /usr/local/bin/nodejs, but many 3rd party tools (bower especially, but I suspect also grunt and gulp) will fail claiming they can't find 'node'

Adding the nodejs-legacy package fixes that on ubuntu:latest
